### PR TITLE
Improve text related to commit distribution

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -240,10 +240,9 @@ line count includes comments, as these are often as important for
 maintainability as the code itself.  Without comments there are $142197$ lines
 of code.} contributed by $232$ unique contributors over $19270$ \texttt{git}
 commits. We can divide up the commits by
-contributor and construct a distribution which is the number of commits
-for each contributor versus the rank of the contributor (where 1 is the
-contributor who has made the most commits, 2 is the contributor with the
-second most commits, and so on). When doing this, we find that this distribution
+contributor and construct a distribution of the number of commits
+per contributor ordered by decreasing number of commits. When doing this,
+we find that this distribution
 follows an approximate power-law (with log-slope of
 $\approx -0.5$), meaning most of the commits were and are contributed by a
 relatively small fraction of the contributor pool.

--- a/main.tex
+++ b/main.tex
@@ -239,8 +239,7 @@ As of version 2.0, \astropypkg contains $212244$ lines of code\footnote{This
 line count includes comments, as these are often as important for
 maintainability as the code itself.  Without comments there are $142197$ lines
 of code.} contributed by $232$ unique contributors over $19270$ \texttt{git}
-commits. We can divide up the commits by
-contributor and construct a distribution of the number of commits
+commits. We can construct a distribution of the number of commits
 per contributor ordered by decreasing number of commits. When doing this,
 we find that this distribution
 follows an approximate power-law (with log-slope of

--- a/main.tex
+++ b/main.tex
@@ -240,8 +240,9 @@ line count includes comments, as these are often as important for
 maintainability as the code itself.  Without comments there are $142197$ lines
 of code.} contributed by $232$ unique contributors over $19270$ \texttt{git}
 commits.
-The commit distribution \inlinecomment{Tom R}{too vague, maybe 'the distribution of number of commits as a function of ...'} follows an approximate power-law (with log-slope of
-$\approx -0.47$) \inlinecomment{AG}{round to -0.5?  This is astronomy, after all.}, meaning most of the commits were and are contributed by a
+The distribution of number of commits as a function of number of contributors
+follows an approximate power-law (with log-slope of
+$\approx -0.5$), meaning most of the commits were and are contributed by a
 relatively small fraction of the contributor pool.
 Roughly half of the commits were contributed by the top $4$
 contributors, while $\sim 90$ percent of the commits came from the top $24$

--- a/main.tex
+++ b/main.tex
@@ -239,8 +239,11 @@ As of version 2.0, \astropypkg contains $212244$ lines of code\footnote{This
 line count includes comments, as these are often as important for
 maintainability as the code itself.  Without comments there are $142197$ lines
 of code.} contributed by $232$ unique contributors over $19270$ \texttt{git}
-commits.
-The distribution of number of commits as a function of number of contributors
+commits. We can divide up the commits by
+contributor and construct a distribution which is the number of commits
+for each contributor versus the rank of the contributor (where 1 is the
+contributor who has made the most commits, 2 is the contributor with the
+second most commits, and so on). When doing this, we find that this distribution
 follows an approximate power-law (with log-slope of
 $\approx -0.5$), meaning most of the commits were and are contributed by a
 relatively small fraction of the contributor pool.


### PR DESCRIPTION
Whoever wrote this text originally - please check that this is correct (is it # of commits vs authors or the other way around). I also rounded the value as suggested by @keflavich.