### PR TITLE
Link directly to astropy project on PyPI

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -308,8 +308,7 @@ The \astropypkg core package is available from several of the \python distributi
 computing, such as Anaconda or Enthought Canopy, which include also some of
 \astropy's affiliated packages.
 Alternatively, \astropypkg can be readily installed from the Python Package
-Index\footnote{\url{https://pypi.python.org/pypi}} (PyPI)
-\inlinecomment{Tom R}{make footnote link directly to astropy on PyPI?}
+Index\footnote{\url{https://pypi.org/project/astropy}} (PyPI)
 using \texttt{pip}, the standard command-line tool for installing \python packages.
 For most recent \astropypkg releases, pre-built wheel distributions are obtainable
 from PyPI for Windows, Mac OS X and Linux systems that provide faster


### PR DESCRIPTION
This requires some reviews, so should not be merged immediately. This uses the new pre-production URL for PyPI with the idea that if this is going to change in the next few months then probably makes sense to use the new URL. Also this links directly to astropy rather than PyPI in general.