### PR TITLE
Remove mention of pip being included by default with Python

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -346,7 +346,7 @@ computing, such as Anaconda or Enthought Canopy, which include also some of
 Alternatively, \astropypkg can be readily installed from the Python Package
 Index\footnote{\url{https://pypi.python.org/pypi}} (PyPI) 
 \inlinecomment{Tom R}{make footnote link directly to astropy on PyPI?}
-using pip, the standard command-line tool for installing \python packages.
+using \texttt{pip}, the standard command-line tool for installing \python packages.
 For most recent \astropypkg releases, pre-built wheel distributions are obtainable
 from PyPI for Windows, Mac OS X and Linux systems that provide faster
 installation compared to the source distribution.

--- a/main.tex
+++ b/main.tex
@@ -346,11 +346,7 @@ computing, such as Anaconda or Enthought Canopy, which include also some of
 Alternatively, \astropypkg can be readily installed from the Python Package
 Index\footnote{\url{https://pypi.python.org/pypi}} (PyPI) 
 \inlinecomment{Tom R}{make footnote link directly to astropy on PyPI?}
-using pip, the
-recommended command-line tool for installing \python packages
-that is included by default since \python 2 $\geq$ 2.7.9 and \python 3 $\geq$ 3.4.
-
-\inlinecomment{Tom R}{is this actually true? I installed Python 3.6 from source recently and it didn't have the pip command readily available. What it does have is the ensurepip module, but we might want to be careful how we phrase this here. Maybe just remove mention of pip being included by default?}
+using pip, the standard command-line tool for installing \python packages.
 For most recent \astropypkg releases, pre-built wheel distributions are obtainable
 from PyPI for Windows, Mac OS X and Linux systems that provide faster
 installation compared to the source distribution.


### PR DESCRIPTION
pip is only included by default with *binary* Python installations so the current wording wasn't quite right. I think we can actually just remove this though and call pip the standard command line tool for installing packages. 