### PR TITLE
Build paper pdf and push to orphan branch if not a PR build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ addons:
             - latexmk
 
 script:
-    - yes X | latexmk -halt-on-error -pdf main
+    - source build-paper-travis.sh

--- a/build-paper-travis.sh
+++ b/build-paper-travis.sh
@@ -4,7 +4,7 @@
 make
 
 # Push to GitHub
-if [ -n "$GITHUB_API_KEY" ]; then
+if [ -n "$GITHUB_API_KEY" ] && ["$TRAVIS_PULL_REQUEST" = "false"]; then
   cd $TRAVIS_BUILD_DIR
   git checkout --orphan $TRAVIS_BRANCH-pdf
   git rm -rf .

--- a/build-paper-travis.sh
+++ b/build-paper-travis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+
+# Build the paper
+make
+
+# Push to GitHub
+if [ -n "$GITHUB_API_KEY" ]; then
+  cd $TRAVIS_BUILD_DIR
+  git checkout --orphan $TRAVIS_BRANCH-pdf
+  git rm -rf .
+  git add -f main.pdf
+  git -c user.name='travis' -c user.email='travis' commit -m "building the paper"
+  git push -q -f https://$GITHUB_USER:$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG $TRAVIS_BRANCH-pdf
+fi


### PR DESCRIPTION
This adds to the travis build to then push the built paper PDF to an orphan branch so that it is viewable. The PDF push should only happen if it is not a pull request build on travis, and the idea was adapted from: https://github.com/dfm/celerite/blob/master/.ci/build-paper.sh