### PR TITLE
Rework io subsection

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -189,6 +189,18 @@ booktitle = {Astronomical Data Analysis Software and Systems XII},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@INPROCEEDINGS{PyFITS,
+   author = {{Barrett}, P.~E. and {Bridgman}, W.~T.},
+    title = "{PyFITS, a FITS Module for Python}",
+booktitle = {Astronomical Data Analysis Software and Systems VIII},
+     year = 1999,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 172,
+   editor = {{Mehringer}, D.~M. and {Plante}, R.~L. and {Roberts}, D.~A.},
+    pages = {483},
+   adsurl = {http://adsabs.harvard.edu/abs/1999ASPC..172..483B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @ARTICLE{Lupton2004,
    author = {{Lupton}, R. and {Blanton}, M.~R. and {Fekete}, G. and {Hogg}, D.~W. and

--- a/main.tex
+++ b/main.tex
@@ -870,20 +870,20 @@ be written out as an HTML table.
 \subsubsection{FITS}
 
 The \package{astropy.io.fits} subpackage started as a direct port of the
-PyFITS project. Therefore it is pretty stable, with mostly bug fixes but also
-a few new features and performance improvements.  The API remains compatible
-with PyFITS, which is now deprecated in favor of Astropy.
+PyFITS project \citep{PyFITS}. Therefore it is pretty stable, with mostly bug
+fixes but also a few new features and performance improvements.  The API
+remains compatible with PyFITS, which is now deprecated in favor of
+\astropypkg.
 
 Command-line scripts are now available for printing a summary of the HDUs in
 a FITS file(s) (\texttt{fitsinfo}) and for printing the header information to
 the screen in a human-readable format (\texttt{fitsheader}).
 
 FITS files are now loaded \emph{lazily} (the default behavior, which can be
-deactivated if needed), where all HDUs are not loaded until they are requested
-(or the file is closed). This should provide substantial speedups for
-situations using the convenience functions (e.g., \texttt{getheader()} or
-\texttt{getdata()}) to get HDU’s that are near the front of a file with many
-HDUs.
+deactivated if needed), where all HDUs are not loaded until they are
+requested. This should provide substantial speedups for situations using the
+convenience functions (e.g., \texttt{getheader()} or \texttt{getdata()}) to
+get HDU’s that are near the front of a file with many HDUs.
 
 % \inlinecomment{Tom R}{too detailed? I don't think we need to mention every single performance enhancement, right?}
 

--- a/main.tex
+++ b/main.tex
@@ -873,8 +873,7 @@ be used.
 
 The \package{astropy.io.ascii} subpackage now provides the capability
 to read a table within an HTML file or web URL into an astropy
-\texttt{Table} object. This requires the \package{BeautifulSoup4}
-package to be installed.  Conversely a \texttt{Table} object can now
+\texttt{Table} object. Conversely a \texttt{Table} object can now
 be written out as an HTML table.
 
 \subsubsection{\texttt{.fits}: command-line scripts (\texttt{fitsheader}, \texttt{fitsinfo})}

--- a/main.tex
+++ b/main.tex
@@ -824,7 +824,6 @@ For many common cases this simplifies the process of file input and output and
 reduces the need to master the separate details of all the I/O packages within
 \astropypkg.
 
-%\inlinecomment{SCO}{Pyfits deprecation in favor of io.fits ?}
 %\inlinecomment{SCO}{Table and FITS tables}
 
 %\subsubsection{Unified file read/write interface}
@@ -869,21 +868,22 @@ to read a table within an HTML file or web URL into an astropy
 be written out as an HTML table.
 
 \subsubsection{FITS}
-% \subsubsection{\texttt{.fits}: command-line scripts (\texttt{fitsheader}, \texttt{fitsinfo})}
 
-The \package{astropy.io.fits} subpackage now provides command-line
-scripts for printing a summary of the HDUs in a FITS file(s)
-(\texttt{fitsinfo}) and for printing the header information
-to the screen in a human-readable format (\texttt{fitsheader}).
+The \package{astropy.io.fits} subpackage started as a direct port of the
+PyFITS project. Therefore it is pretty stable, with mostly bug fixes but also
+a few new features and performance improvements.  The API remains compatible
+with PyFITS, which is now deprecated in favor of Astropy.
 
-% \subsubsection{\texttt{.fits}: lazy loading }
+Command-line scripts are now available for printing a summary of the HDUs in
+a FITS file(s) (\texttt{fitsinfo}) and for printing the header information to
+the screen in a human-readable format (\texttt{fitsheader}).
 
-The \package{astropy.io.fits} subpackage now supports \emph{lazy
-loading}, where all HDUs are not loaded until they are requested (or
-the file is closed). This should provide substantial speedups for
-situations using the convenience functions (e.g., \texttt{getheader()}
-or \texttt{getdata()}) to get HDU’s that are near the front of a file
-with many HDUs.
+FITS files are now loaded \emph{lazily} (the default behavior, which can be
+deactivated if needed), where all HDUs are not loaded until they are requested
+(or the file is closed). This should provide substantial speedups for
+situations using the convenience functions (e.g., \texttt{getheader()} or
+\texttt{getdata()}) to get HDU’s that are near the front of a file with many
+HDUs.
 
 % \inlinecomment{Tom R}{too detailed? I don't think we need to mention every single performance enhancement, right?}
 

--- a/main.tex
+++ b/main.tex
@@ -831,60 +831,52 @@ reduces the need to master the separate details of all the I/O packages within
 
 %\inlinecomment{Check when it was added (0.3?). Overview of the supported formats (ASCII,FITS, votable, HTML, JSViewer/Datatables).}
 
-We summarize key new features or updates to \package{astropy.io} below,
-organized by sub-subpackage.
+% We summarize key new features or updates to \package{astropy.io} below,
+% organized by sub-subpackage.
 
-\inlinecomment{Tom R}{is a sub-subpackage a thing, or is it just 'subpackage' all the way down?}
+% \inlinecomment{Tom R}{is a sub-subpackage a thing, or is it just 'subpackage' all the way down?}
 
-\subsubsection{Enhanced CSV format}
+\subsubsection{ASCII}
+% \subsubsection{Enhanced CSV format}
 
 One of the problems when storing a table in an ASCII format is
 preserving table meta-data such as comments, keywords and column data
-types, units, and descriptions. Using the newly defined \emph{Enhanced
-Character Separated Values} (ECSV,  \citet{ape6}) format it is now
+types, units, and descriptions. The newly defined \emph{Enhanced
+Character Separated Values} (ECSV,  \citet{ape6}) format makes it
 possible to write a table to an ASCII-format file and read it back
 with no loss of information. The ECSV format has been designed to be
 both human-readable and compatible with most simple CSV readers.
 
-\subsubsection{\texttt{.ascii}: fast readers and writers}
+% \subsubsection{\texttt{.ascii}: fast readers and writers}
 
-The \package{astropy.io.ascii} module now includes a significantly
-faster Cython/C engine for reading and writing ASCII files. This is
-available for the most common formats.
+The \package{astropy.io.ascii} subpackage now includes a significantly faster
+Cython/C engine for reading and writing ASCII files. This is available for the
+most common formats.  On average the new engine is about 4 to 5 times faster
+than the corresponding pure-\python implementation, and is often comparable to
+the speed of the \package{Pandas} \citep{pandas} ASCII file interface.  The
+fast reader has parallel processing option that allows harnessing multiple
+cores for input parsing to achieve even greater speed gains.  By default,
+\texttt{read()} and \texttt{write()} will attempt to use the fast C engine
+when dealing with compatible formats. Certain features of the full read
+/ write interface are not available in the fast version, in which case the
+pure-\python version will automatically be used.
 
-%following formats: \texttt{basic},
-%      \texttt{commented\_header}, \texttt{csv}, \texttt{no\_header},
-%      \texttt{rdb}, and \texttt{tab}.
-On average the new engine is about
-4 to 5 times faster than the corresponding pure-\python
-implementation, and is often comparable to the speed of the
-\package{Pandas} \citep{pandas} ASCII file interface.  The fast
-reader has parallel processing option that allows harnessing
-multiple cores for input parsing to achieve even greater speed
-gains.
-
-By default, \texttt{read()} and \texttt{write()} will attempt to use
-the fast C engine when dealing with compatible formats. Certain
-features of the full read / write interface are not available in the
-fast version, in which case the pure-\python version will automatically
-be used.
-
-\subsubsection{\texttt{.ascii}: HTML tables}
+% \subsubsection{\texttt{.ascii}: HTML tables}
 
 The \package{astropy.io.ascii} subpackage now provides the capability
 to read a table within an HTML file or web URL into an astropy
 \texttt{Table} object. Conversely a \texttt{Table} object can now
 be written out as an HTML table.
 
-\subsubsection{\texttt{.fits}: command-line scripts (\texttt{fitsheader}, \texttt{fitsinfo})}
+\subsubsection{FITS}
+% \subsubsection{\texttt{.fits}: command-line scripts (\texttt{fitsheader}, \texttt{fitsinfo})}
 
 The \package{astropy.io.fits} subpackage now provides command-line
 scripts for printing a summary of the HDUs in a FITS file(s)
-(\texttt{fitsinfo file.fits}) and for printing the header information
-to the screen in a human-readable format (\texttt{fitsheader
-file.fits}).
+(\texttt{fitsinfo}) and for printing the header information
+to the screen in a human-readable format (\texttt{fitsheader}).
 
-\subsubsection{\texttt{.fits}: lazy loading }
+% \subsubsection{\texttt{.fits}: lazy loading }
 
 The \package{astropy.io.fits} subpackage now supports \emph{lazy
 loading}, where all HDUs are not loaded until they are requested (or
@@ -893,15 +885,14 @@ situations using the convenience functions (e.g., \texttt{getheader()}
 or \texttt{getdata()}) to get HDU’s that are near the front of a file
 with many HDUs.
 
-\inlinecomment{Tom R}{too detailed? I don't think we need to mention every single performance enhancement, right?}
+% \inlinecomment{Tom R}{too detailed? I don't think we need to mention every single performance enhancement, right?}
 
-\subsubsection{\texttt{.misc}: YAML serialization}
+% \subsubsection{\texttt{.misc}: YAML serialization}
 
-The new \package{astropy.io.misc.yaml} module allows converting
-astropy objects into a standard YAML format.
-This can be used beyond \texttt{astropy.io.misc.yaml}: for example, to
-serialize the metadata of tables before saving to other formats like
-HDF5.
+% The new \package{astropy.io.misc.yaml} module allows converting astropy
+% objects into a standard YAML format.  This can be used beyond
+% \texttt{astropy.io.misc.yaml}: for example, to serialize the metadata of
+% tables before saving to other formats like HDF5.
 
 
 %\inlinecomment{BMS}{Maybe move the command line tools into a separate subsection to highlight them (even though we mostly only have fits related scripts)? They are supposed to be used more frequently by individual users.}


### PR DESCRIPTION
- Group the ASCII and FITS paragraphs to have only two subsections, and remove the YAML one which was too technical 
- Mention the PyFITS origin and deprecation, and rework the io.fits paragraph.
