### PR TITLE
fix broken \url{}s

### DIFF
--- a/aastex61.cls
+++ b/aastex61.cls
@@ -6291,7 +6291,7 @@ width 0pt\relax\fi}}}
 \def\email#1{{\let\ltx@footmark\tempfootmark
 \saveemail{}}
 {\renewcommand\thefootnote{\hskip-12.1pt}
-\footnote{\href{mailto: #1}{#1}\ifmodern\vrule depth 7pt width
+\footnote{\href{mailto:#1}{#1}\ifmodern\vrule depth 7pt width
 0pt\relax\else\ifmanu\vskip-4pt\else\vrule depth 7pt width 0pt\fi\fi}}}
 
 

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -930,9 +930,9 @@ booktitle = {Astronomical Data Analysis Software and Systems XXI},
   title        = {{Vision for Astropy Spectroscopic Tools (APE 13)}},
   author       = {{Crawford}, S.~M. and {Earl}, N. and {Ginsburg}, A. and {Tollerud}, E.},
   month        = may,
-  year         = {in prep.},
-  doi          = {in prep.},
-  url          = {in prep.}
+  year         = {in prep.},  %% FIXME
+  doi          = {in prep.},  %% FIXME
+%  url          = {in prep.}  %% FIXME
 }
 
 

--- a/main.tex
+++ b/main.tex
@@ -1080,8 +1080,8 @@ developed by the \astropy Project.
 % Brigitta may write this up if there is no other takers
 
 \astropy provides a package template --- as a separate \github repository,
-\package{astropy/package-template}\footnote{\url{https://github.com/astropy/package-t
-emplate/}} --- that aims to simplify setting up packaging, testing, and
+\package{astropy/package-template}\footnote{\url{https://github.com/astropy/package-template/}}
+--- that aims to simplify setting up packaging, testing, and
 documentation builds for developers of affiliated packages or
 \astropypkg-dependent packages.
 Any \python package can make use of this ready-to-go package layout, setup,

--- a/main.tex
+++ b/main.tex
@@ -197,8 +197,8 @@ core codebase.
 Bugs and feature requests are reported via the \github issue tracker and labeled
 with a set of possible labels that help classify and organize the issues.
 The development workflow is detailed in the \astropypkg
-documentation.\footnote{\emph{How to make a code contribution}, \url{http://docs.
-astropy.org/en/stable/development/workflow/development_workflow.html}}
+documentation.\footnote{\emph{How to make a code contribution},
+\url{http://docs.astropy.org/en/stable/development/workflow/development_workflow.html}}
 
 \begin{figure}
 \includegraphics[width=\textwidth]{ncommits.pdf}


### PR DESCRIPTION
Fix broken \url{} link to docs.astropy.org.