### PR TITLE
edit to description of Fig 1 in text

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -229,7 +229,7 @@ effort and is not dominated by a single individual.
 It is also important to note that the number of commits is only a rough metric
 of contribution, as a single commit could be a critical fix in the package or a
 fix for a typographical error.
-\figurename~\ref{fig:ncommits}, right, shows the number of contributors as a
+\figurename~\ref{fig:ncommits}, right, shows the number of commits as a
 function of time since the genesis of the \astropypkg core package.
 The package is still healthy: new commits are and have been contributed at a
 steady rate throughout its existence.


### PR DESCRIPTION
now matches figure and its caption - number of commits, not number of contributors.