### PR TITLE
Remove extraneous Overview subsubsection from modeling

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -449,7 +449,7 @@ trigonometric functions expect) before being passed to \texttt{numpy}.
         \texttt{astropy.units} provides a tool called \texttt{quantity\_input()}
         that can perform this varification automatically to avoid repetitive
         code.
-        
+
 
 \subsection{Constants}
 % David S.
@@ -882,7 +882,7 @@ get HDU’s that are near the front of a file with many HDUs.
 % The whole modeling submodule was missing from the previous paper, so everything really, including compound models, unit support etc.
 % Nadia, Lim
 % Tom R. -- unit support
-\subsubsection{Overview}
+
 The \package{astropy.modeling} subpackage provides a framework for representing
 analytical models and performing model evaluation and parameter fitting. Models and
 fitters are independent of each other: a model can be fit with different


### PR DESCRIPTION
Address part of #43 by removing  extraneous "Overview" subsubsection from `modeling` subsection.

c/c @nden