### PR TITLE
Replace "summer" with "mid-"

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1178,8 +1178,8 @@ Removing \python 2 support will allow the use of new, \python 3-only features,
 will simplify the code base, and reduce the testing overhead for the package.
 \astropypkg version 3.0 is currently scheduled for January 2018.
 
-In the next major release after version 3.0, scheduled for the summer of
-2018, the focus will be on optimization of the code and improved
+In the next major release after version 3.0, scheduled for around
+mid-2018, the focus will be on optimization of the code and improved
 documentation.
 To prepare for this release, we are preparing software for testing, evaluating,
 and monitoring the performance of the code.

--- a/main.tex
+++ b/main.tex
@@ -1178,7 +1178,7 @@ Removing \python 2 support will allow the use of new, \python 3-only features,
 will simplify the code base, and reduce the testing overhead for the package.
 \astropypkg version 3.0 is currently scheduled for January 2018.
 
-In the next major release after version 3.0, scheduled for around
+In the next major release after version 3.0, scheduled for
 mid-2018, the focus will be on optimization of the code and improved
 documentation.
 To prepare for this release, we are preparing software for testing, evaluating,


### PR DESCRIPTION
Fix #66 

p.s. ~~June~~ "mid" is obtained from timeline at https://github.com/astropy/astropy-APEs/blob/master/APE10.rst

p.p.s. (Angry fist at Earth's tilt)