### PR TITLE
intro: remove two non-sequitur sentences

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -134,10 +134,6 @@ standard \citep{FITS} and maintain software for such a general-purpose need.
 Another example of such a common task is in dealing with representations of and
 transformations between astronomical coordinate systems.
 
-The \astropy project aims to develop and provide high-quality code and
-documentation according to the best practices in software development.
-The project makes use of these tools to do so without central institutional
-oversight.
 The first public release of the \astropypkg package is described in
 \cite{astropy}. Since then, the \astropypkg package has been
 used in hundreds of projects and the scope of the package has grown


### PR DESCRIPTION
The point of this paragraph is to briefly state the relevant history, and to describe the current state of astropy.

A general statement about aims would belong further up (I'm not sure where, so I did not put it anywhere). The object of "these tools" in original wording was not clear.