### PR TITLE
Improve wording for unclear reference of "those tools" (alternative to #77)

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -135,8 +135,8 @@ transformations between astronomical coordinate systems.
 
 The \astropy project aims to develop and provide high-quality code and
 documentation according to the best practices in software development.
-The project makes use of these tools to do so without central institutional
-oversight.
+The project makes use of different tools and web serverices to reach those
+goals without central institutional oversight.
 The first public release of the \astropypkg package is described in
 \cite{astropy}. Since then, the \astropypkg package has been
 used in hundreds of projects and the scope of the package has grown

--- a/main.tex
+++ b/main.tex
@@ -135,7 +135,7 @@ transformations between astronomical coordinate systems.
 
 The \astropy project aims to develop and provide high-quality code and
 documentation according to the best practices in software development.
-The project makes use of different tools and web serverices to reach those
+The project makes use of different tools and web services to reach those
 goals without central institutional oversight.
 The first public release of the \astropypkg package is described in
 \cite{astropy}. Since then, the \astropypkg package has been


### PR DESCRIPTION
This is an alternative implementation for #77, which keeps the
aims and goal sentence intact, but rewords the second sentence
where it is unclear what "those tools" refers to.

closes #77