### PR TITLE
Tone-down generalisation "All astronomical research"->"All modern astronomical research"

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -77,7 +77,7 @@ broader \astropy project.
 
 
 \section{Introduction} \label{sec:intro}
-All astronomical research makes use of software in some way.
+All modern astronomical research makes use of software in some way.
 Astronomy as a field has thus long supported the development of software tools
 for astronomical tasks, such as scripts that enable individual scientific
 research, software packages for small collaborations, and data reduction


### PR DESCRIPTION
Reduce the opening generalisation slightly to reflect several previous millennia of work in astronomy.  This changes:
* "**All** astronomical research makes use of software in some way."

to:
* "**All modern** astronomical research makes use of software in some way."
  
  