### PR TITLE
Normalise Heidelberg postal addresses

### DIFF
--- a/author.tex
+++ b/author.tex
@@ -105,7 +105,7 @@
 \noaffiliation
 
 \author{F. Biscani}
-\affiliation{Max-Planck-Institut f\"ur Astronomie, K\"onigstuhl 17, D-69117 Heidelberg, Germany}
+\affiliation{Max-Planck-Institut f\"ur Astronomie, K\"onigstuhl 17, 69117 Heidelberg, Germany}
 
 \author[0000-0003-0946-6176]{M. Boquien}
 \affiliation{Unidad de Astronomía, Fac. Cs. Básicas, Universidad de Antofagasta, Avda. U. de Antofagasta 02800, Antofagasta, Chile}
@@ -216,7 +216,7 @@
 \affiliation{\afgemini}
 
 \author[0000-0002-8546-9128]{D. Homeier}
-\affiliation{Zentrum f{\"u}r Astronomie der Universit{\"a}t Heidelberg, Landessternwarte, K{\"o}nigstuhl 12, D-69117 Heidelberg, Germany}
+\affiliation{Zentrum f{\"u}r Astronomie der Universit{\"a}t Heidelberg, Landessternwarte, K{\"o}nigstuhl 12, 69117 Heidelberg, Germany}
 
 \author[0000-0002-4600-7852]{A. J. Horton}
 \affiliation{Australian Astronomical Observatory, 105 Delhi Road, North Ryde NSW 2113, Australia}
@@ -378,7 +378,7 @@
 \affiliation{Joint Space-Science Institute, University of Maryland, College Park, MD 20742, USA}
 
 \author[0000-0003-1585-225X]{P. H. Sladen}
-\affiliation{ARI/ZAH, Heidelberg}
+\affiliation{Zentrum f{\"u}r Astronomie der Universit{\"a}t Heidelberg, Astronomisches Rechen-Institut, M{\"o}nchhofstra{\ss}e 12--14, 69120 Heidelberg, Germany}
 
 \author{K. A. Sooley}
 \noaffiliation


### PR DESCRIPTION
Semi-normalise postal address format for some of the Heidelberg Institutes + expand ARI full address.