### PR TITLE
D. Homeier typo fixes and some comments on `io`

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -36,7 +36,16 @@ archivePrefix = "arXiv",
 	Pages = {A33},
 	Title = {{Astropy: A community Python package for astronomy}},
 	Volume = 558,
-	Year = 2013}
+	Year = 2013,
+archivePrefix = "arXiv",
+   eprint = {1307.6212},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
+      eid = {A33},
+      doi = {10.1051/0004-6361/201322068},
+   adsurl = {http://esoads.eso.org/abs/2013A%26A...558A..33A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
 @article{numpy,
   Author = {{Van der Walt}, {Stefan} and Colbert, S. Chris and Varoquaux, Gael},

--- a/main.tex
+++ b/main.tex
@@ -768,7 +768,10 @@ It also provides a unified interface for reading and writing data with these
 different formats using the \package{astropy.table} subpackage.
 For many common cases, this simplifies the process of file input and output (I/O) and
 reduces the need to master the separate details of all the I/O packages within
-\astropypkg.
+\astropypkg. The file interface allows transparent compression of
+the \texttt{gzip}, \texttt{bzip2} and \texttt{lzma} (\texttt{.xz})
+formats; for the latter two if the Python installation was compiled
+with support the respective libraries.
 
 \subsubsection{ASCII}
 
@@ -782,7 +785,9 @@ both human-readable and compatible with most simple CSV readers.
 
 The \package{astropy.io.ascii} subpackage now includes a significantly faster
 Cython/C engine for reading and writing ASCII files. This is available for most
-of the common formats.  On average, the new engine is about 4 to 5 times faster
+of the common formats. It also offers some additional features like parsing
+of different exponential notation styles, such as commonly produced
+by Fortran programs.  On average, the new engine is about 4 to 5 times faster
 than the corresponding pure-\python implementation and is often comparable to
 the speed of the \package{pandas} \citep{pandas} ASCII file interface.  The
 fast reader has parallel processing option that allows harnessing multiple
@@ -790,7 +795,7 @@ cores for input parsing to achieve even greater speed gains.  By default,
 \texttt{read()} and \texttt{write()} will attempt to use the fast Cython/C engine
 when dealing with compatible formats. Certain features of the full read
 / write interface are unavailable in the fast version, in which case the
-pure-\python version will automatically be used.
+reader will by default fall back automatically to the pure-\python version.
 
 The \package{astropy.io.ascii} subpackage now provides the capability
 to read a table within an HTML file or web URL into an \astropypkg

--- a/main.tex
+++ b/main.tex
@@ -1363,7 +1363,8 @@ Foundation of South Africa. TLA was supported by NASA contract NAS8-03060. Suppo
 through Hubble Fellowship grant No. 51316.01 awarded by the Space Telescope Science Institute, which is operated by
 the Association of Universities for Research in Astronomy, Inc., for NASA, under contract NAS 5-26555, as well as a 
 Giacconi Fellowship. MB was supported by the FONDECYT regular project 1170618 and the MINEDUC-UA projects codes 
-ANT 1655 and ANT 1656. DH was supported through the SFB 881 "The Milkyway System" by the German Research Foundation 
+ANT 1655 and ANT 1656. DH was supported through the SFB 881 ``The
+Milky Way System'' by the German Research Foundation 
 (DFG). WEK was supported by an ESO Fellowship. C.M. is supported by NSF grant AST-1313484. SP was supported by 
 grant AYA2016-75808-R (FEDER) issued by the Spanish government. JEHT was supported by the Gemini Observatory, which
 is operated by the Association of Universities for Research in Astronomy, Inc., on behalf of the international 


### PR DESCRIPTION
Sorry for the last-minute additions, some clarifications on `io.ascii`, and I added a few lines on HDF5 I/O, which has not been covered at all so far. Might be arguable if it warrants its own subsection, but since it is one of the principal supported formats, this seems justified for symmetry.
Also completed the `.bib` entry for Paper I - the `aasjournal` style makes no use of the arXiv and doi fields, but the electronic journal certainly will.

Another note on (future) data formats - wondering if @embray or @mdboom have any comments on the role they see for [`ASDF`](https://doi.org/10.1016/j.ascom.2015.06.004) in astropy at this point.