### PR TITLE
Added subsection with brief description of HDF5 I/O

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -821,6 +821,16 @@ when using the convenience functions (e.g., \texttt{getheader()} or
 \texttt{getdata()}) to get an HDU that is near the beginning in a file with
 many HDUs.
 
+\subsubsection{HDF5}
+
+The \package{astropy.io.misc.hdf5} subpackage provides support for binary
+read and write access to files in the \emph{Hierarchical Data Format}
+(HDF5), if the \package{h5py} package is installed. Astropy table I/O
+is offered transparently through \texttt{Table.read()} and
+\texttt{Table.write()}, analogously to the other auto-detected
+formats. The keyword \texttt{path='group/subgroup/dataset'} specifies
+the path to the data inside the file's hierarchical structure.
+
 \subsection{Modeling}
 \label{sec:modeling}
 % The whole modeling submodule was missing from the previous paper, so everything really, including compound models, unit support etc.


### PR DESCRIPTION
Pulled out of #130 on suggestion from @crawfordsm for later consideration (possibly on resubmission). On a quick glance, since early 2013 the only major updates to `io.misc.hdf5` have been improved access to individual datasets inside the file (as partly alluded to in the description of `path=...`) and handling of meta-data. However the entire module was not covered in Paper I at all, and being one of the 3/4 principal supported data formats it would seem to deserve a `subsubsection` of its own.

Things to do:

- find a reference (`@manual` with doi...) for h5py
- lay out changes since ~ v1.0.2