### PR TITLE
Update collaboration author

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -11,7 +11,7 @@
 \submitjournal{ApJ}
 
 \shorttitle{Astropy Project II}
-\shortauthors{Astropy Project et al.}
+\shortauthors{The Astropy Collaboration}
 
 % Packages / projects / programming - for consistency!
 \newcommand{\package}[1]{\texttt{#1}\xspace}
@@ -43,7 +43,7 @@
 \correspondingauthor{Astropy Coordination Committee}
 \email{coordinators@astropy.org}
 
-\author{Astropy Project}
+\author{The Astropy Collaboration}
 \noaffiliation
 {\let\thefootnote\relax\footnote{{The author list has three parts: the authors that made significant contributions to the writing of the paper in order of contribution, the four members of the \astropy Project coordination committee, and contributors to the \astropy Project in alphabetical order. The position in the author list does not correspond to contributions to the \astropy Project as a whole. A more complete list of contributors to the core package can be found in the \href{https://github.com/astropy/astropy/graphs/contributors}{package repository}, and at the \href{http://www.astropy.org/team.html}{\astropy team webpage}.}}}
 


### PR DESCRIPTION
As suggested on Slack, I think the collaboration author should match the first paper to allow e.g. Astropy Collaboration (2013, 2018). The collaboration is better terminology since the project is the people + the code.