### PR TITLE
Change title to say core package instead of software

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -38,7 +38,7 @@
 
 \draft{\today}
 
-\title{The Astropy Project: Building an inclusive, open-science project and status of the v2.0 software}
+\title{The Astropy Project: Building an inclusive, open-science project and status of the v2.0 core package}
 
 \correspondingauthor{Astropy Coordination Committee}
 \email{coordinators@astropy.org}


### PR DESCRIPTION
There is not just one software in the Astropy Project, so I think we need to be more specific.