### PR TITLE
Solution for issue 137 (response to referee report)

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -38,7 +38,7 @@
 
 \draft{\today}
 
-\title{The Astropy Project: Building an inclusive, open-science project and status of the v2.0 core package}
+\title{The Astropy Project: Building an open-science project and status of the v2.0 core package}
 
 \correspondingauthor{Astropy Coordination Committee}
 \email{coordinators@astropy.org}


### PR DESCRIPTION
In response to Issue #137 -- I modified the paper title to remove the word "inclusive". After all, it appears nowhere else in the paper and the paper does not define it. This should be a topic for later.

Response to referee:

We thank the referee for bringing up this important point. After some discussion within the Astropy community, it became clear that a section regarding inclusion is beyond the scope of the current paper. Quantitative analysis of the Astropy community demographics is warranted. However, this is a serious undertaking beyond the capabilities of our community, and it may require IRB approval. Based on the referee's comment, we have established initial contact with the NumFOCUS Diversity & Inclusion in Scientific Computing (DISC) program. Results will not be available in time for this paper. We have opted to remove "inclusive" from the paper title to make room for future study and dialogue.