### PR TITLE
Add links to stable documentation

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -34,6 +34,17 @@
 \newcommand{\inlinecomment}[2]{\todo[inline]{#1: #2}\xspace}
 \newcommand{\comment}[2]{\todo{#1: #2}\xspace}
 
+% Links to documentation: subpackages
+\newcommand{\astropysubpkg}[1]{\href{http://docs.astropy.org/en/stable/#1/index.html}{\texttt{astropy.#1}}\xspace}
+\newcommand{\astropyiosubpkg}[1]{\href{http://docs.astropy.org/en/stable/io/#1/index.html}{\texttt{astropy.io.#1}}\xspace}
+\newcommand{\astropywcsaxes}{\href{http://docs.astropy.org/en/stable/visualization/wcsaxes/index.html}{\texttt{astropy.visualization.wcsaxes}}\xspace}
+
+% Links to documentation: classes
+\newcommand{\astropyskycoord}{\href{http://docs.astropy.org/en/stable/api/astropy.coordinates.SkyCoord.html}{\texttt{SkyCoord}}\xspace}
+\newcommand{\astropyQuantity}{\href{http://docs.astropy.org/en/stable/api/astropy.units.Quantity.html}{\texttt{Quantity}}\xspace}
+\newcommand{\astropyTime}{\href{http://docs.astropy.org/en/stable/api/astropy.time.Time.html}{\texttt{Time}}\xspace}
+\newcommand{\astropyTable}{\href{http://docs.astropy.org/en/stable/api/astropy.table.Table.html}{\texttt{Table}}\xspace}
+
 \begin{document}
 
 \draft{\today}
@@ -286,7 +297,7 @@ libraries) that make these packages more suitable to be separate from the
 \astropypkg core package.
 Affiliated packages may also be used to develop substantial new functionality
 that will eventually be incorporated into the \astropypkg core package
-(e.g., \texttt{wcsaxes}).
+(e.g., \astropywcsaxes).
 New functionality benefits from having a rapid development and release cycle that is not tied to that of the \astropypkg core (\sectionname~\ref{sect:releasecycle}).
 
 Affiliated packages are listed on the main \astropy website and advertised to
@@ -359,7 +370,8 @@ are commonly needed in a large subset of the astronomical community.
 At the foundation is the \astropypkg core package, which provides general
 functionality (e.g., coordinate transformations, reading and writing
 astronomical files, and units) or base classes for other
-packages to utilize for a common interface (e.g., \texttt{NDData}).
+packages to utilize for a common interface (e.g.,
+\href{http://docs.astropy.org/en/stable/nddata/index.html}{\texttt{NDData}}).
 In this section, we highlight new features introduced or substantially improved
 since version 0.2 (previously described in \citealt{astropy}).  The \astropypkg
 package
@@ -371,19 +383,19 @@ since the release of the version 0.2 package.
 
 \subsection{Units}\label{sec:units}
 
-The \texttt{astropy.units} subpackage adds support for representing units and
+The \astropysubpkg{units} subpackage adds support for representing units and
 numbers with associated units --- ``quantities'' --- in code.
 Historically, quantities in code have often been represented simply as numbers,
 with units implied or noted via comments in the code because of considerations
 about speed: having units associated with numbers inherently adds overhead to
 numerical operations.
-In \texttt{astropy.units}, \texttt{Quantity} objects extend \texttt{numpy}
+In \astropysubpkg{units}, \astropyQuantity objects extend \texttt{numpy}
 array objects and have been designed with speed in mind.
 
 As of \astropypkg version 2.0, units and quantities, prevalent in most of its
 subpackages, have become a key concept for using the package as a whole.
 Units are intimately entwined in the definition of astronomical coordinates;
-thus, nearly all functionality in the \texttt{astropy.coordinates} subpackage
+thus, nearly all functionality in the \astropysubpkg{coordinates} subpackage
 (see \sectionname~\ref{sec:coordinates}) depends on them.
 For most other subpackages, quantities are at least accepted and often expected
 by default.
@@ -394,10 +406,10 @@ features and improvements here.
 
 \subsubsection{Interaction with \package{numpy} arrays}
 
-\texttt{Quantity} objects extend
+\astropyQuantity objects extend
 \texttt{numpy.ndarray} objects and therefore
 work well with many of the functions in \texttt{numpy} that support
-array operations. For example, \texttt{Quantity} objects with angular
+array operations. For example, \astropyQuantity objects with angular
 units can be directly passed in to the trigonometric functions implemented in
 \texttt{numpy}. The units are internally converted to radians, which is what
 the \texttt{numpy} trigonometric functions expect, before being passed to
@@ -405,30 +417,30 @@ the \texttt{numpy} trigonometric functions expect, before being passed to
 
 \subsubsection{Logarithmic units and magnitudes}
         By default, taking the logarithm of
-        a \texttt{Quantity} object with non-dimensionless units intentionally
+        a \astropyQuantity object with non-dimensionless units intentionally
         fails.
         However, some well-known units are actually logarithmic quantities,
         where the logarithm of the value is taken with respect to some reference
         value.
         Examples include astronomical magnitudes, which are logarithmic fluxes,
         and decibels, which are more generic logarithmic ratios of quantities.
-        Logarithmic, relative units are now supported in \texttt{astropy.units}.
+        Logarithmic, relative units are now supported in \astropysubpkg{units}.
 
 \subsubsection{Defining functions that require quantities}
         When writing code or
-        functions that expect \texttt{Quantity} objects, we often want to
+        functions that expect \astropyQuantity objects, we often want to
         enforce that the input units have the correct physical type.
-        For example, we may want to require only length-type \texttt{Quantity}
+        For example, we may want to require only length-type \astropyQuantity
         objects.
-        \texttt{astropy.units} provides a tool called \texttt{quantity\_input()}
+        \astropysubpkg{units} provides a tool called \href{http://docs.astropy.org/en/stable/api/astropy.units.quantity_input.html}{\texttt{quantity\_input()}}
         that can perform this verification automatically to avoid repetitive
         code.
 
 
 \subsection{Constants}
 
-The \texttt{astropy.constants} subpackage provides a selection of physical and
-astronomical constants as \texttt{Quantity} objects (see
+The \astropysubpkg{constants} subpackage provides a selection of physical and
+astronomical constants as \astropyQuantity objects (see
 \sectionname~\ref{sec:units}).
 A brief description of this package was given in \cite{astropy}.
 In version 2.0, the built-in constants have been organized into modules for
@@ -445,9 +457,9 @@ is available and provides access to the adopted versions of the
 constants from earlier versions of \astropypkg.
 To use previous versions of the constants as \emph{units} (e.g., solar masses),
 the values have to be imported directly; with version
-2.0, \texttt{astropy.units} uses the \texttt{astropyconst20} versions.
+2.0, \astropysubpkg{units} uses the \texttt{astropyconst20} versions.
 
-Astronomers using \texttt{astropy.constants} should take particular note of the
+Astronomers using \astropysubpkg{constants} should take particular note of the
 constants provided for Earth, Jupiter, and the Sun.
 Following IAU 2015 Resolution B3 \citep{iau2015b3}, nominal values are now given
 for mass parameters and radii.
@@ -456,10 +468,10 @@ updated.
 
 \subsection{Coordinates}
 \label{sec:coordinates}
-The \package{astropy.coordinates} subpackage is designed to support representing
+The \astropysubpkg{coordinates} subpackage is designed to support representing
 and transforming celestial coordinates and, new in version 2.0, velocities.
-The framework heavily relies on the \package{astropy.units} subpackage, and most
-inputs to objects in this subpackage are expected to be \texttt{Quantity}
+The framework heavily relies on the \astropysubpkg{units} subpackage, and most
+inputs to objects in this subpackage are expected to be \astropyQuantity
 objects.
 Some of the machinery also relies on the Essential Routines of Fundamental
 Astronomy (ERFA) \texttt{C} library for some of the critical underlying
@@ -503,7 +515,7 @@ If required, these additional frame attributes must be specified along with the
 coordinate data when a \texttt{Frame} object is created.
 \figurename~\ref{fig:frame-transform-graph} shows the network of possible
 reference frame transformations as currently implemented in
-\texttt{astropy.coordinates}.
+\astropysubpkg{coordinates}.
 Custom user-implemented \texttt{Frame} classes that define transformations to
 any reference frame in this graph can then be transformed to any of the other
 connected frames.
@@ -512,7 +524,7 @@ connected frames.
 \includegraphics[width=\textwidth]{coordinates_graph.pdf}
 \caption{%
     The full graph of possible reference frame transformations implemented in
-    \texttt{astropy.coordinates}.
+    \astropysubpkg{coordinates}.
     Arrows indicate transformations from one frame to another.
     Arrows that point back to the same frame indicate self-transformations that
     involve a change of reference frame parameters (e.g., equinox).
@@ -522,15 +534,15 @@ connected frames.
 
 The typical user does not usually have to interact with the \texttt{Frame} or
 \texttt{Representation} classes directly.
-Instead, \texttt{astropy.coordinates} provides a high-level interface to
-representing astronomical coordinates through the \texttt{SkyCoord} class,
+Instead, \astropysubpkg{coordinates} provides a high-level interface to
+representing astronomical coordinates through the \astropyskycoord class,
 which was designed to provide a single class that
 accepts a wide range of possible inputs.
 It supports coordinate data in any coordinate frame in any representation by
 internally using the \texttt{Frame} and \texttt{Representation} classes.
 
 In what follows, we briefly highlight key new features in
-\texttt{astropy.coordinates}.
+\astropysubpkg{coordinates}.
 
 \subsubsection{Local Earth coordinate frames}
 In addition to representing celestial
@@ -540,7 +552,7 @@ In addition to representing celestial
     With this, \astropypkg now supports Earth-location-specific coordinate
     systems such as the altitude-azimuth (\texttt{AltAz}) or horizontal system.
     Transformations between \texttt{AltAz} and any Barycentric coordinate frame
-    also requires specifying a time using the \texttt{Time} class from
+    also requires specifying a time using the \astropyTime class from
     \texttt{astropy.time}.
     With this new functionality, many of the common tasks associated with
     observation planning can now be completed with \astropypkg or the
@@ -559,7 +571,7 @@ In addition to representing celestial
     transformations are done numerically instead of analytically.
     The low-level interface for specifying and transforming velocity data  is
     currently experimental.  As such, in version 2.0, only the \texttt{Frame}
-    classes (and not the \texttt{SkyCoord} class) support handling velocities.
+    classes (and not the \astropyskycoord class) support handling velocities.
 
 \subsubsection{Solar System Ephemerides}
     Also new is support for computing ephemerides of major solar system bodies
@@ -572,7 +584,7 @@ In addition to representing celestial
 \subsubsection{Accuracy of coordinate transformations}
 
 In order to check the accuracy of the coordinate transformations in
-\package{astropy.coordinates}, we have created a set of benchmarks that we use
+\astropysubpkg{coordinates}, we have created a set of benchmarks that we use
 to compare transformations between a set of coordinate frames for a number of
 packages\footnote{\url{http://www.astropy.org/coordinates-benchmark/summary.html}}.
 Since no package can be guaranteed to implement all transformations to
@@ -629,12 +641,12 @@ benchmarks are refined and the packages updated.
 \subsection{Time}
 \label{sec:time}
 
-The \package{astropy.time} subpackage focuses on supporting time scales (e.g.,
+The \astropysubpkg{time} subpackage focuses on supporting time scales (e.g.,
 UTC, TAI, UT1) and time formats (e.g., Julian date, modified Julian date) that
 are commonly used in astronomy.
 This functionality is needed, for example, to calculate barycentric corrections
 or sidereal times.
-\package{astropy.time} is currently built on the ERFA (\citealt{erfa}) C
+\astropysubpkg{time} is currently built on the ERFA (\citealt{erfa}) C
 library, which replicates the Standards of Fundamental Astronomy (SOFA;
 \citealt{sofa}) but is licensed under a three-clause BSD license.
 The package was described in detail in  \citet{astropy} and has
@@ -649,18 +661,18 @@ source to the observatory because of the Earth's motion.
 It is therefore common to instead convert times to the Solar System
 barycenter or heliocenter where the relative timing of photons is
 standardized.
-With the location of a source on the sky (i.e., a \texttt{SkyCoord}
+With the location of a source on the sky (i.e., a \astropyskycoord
 object), the location of an observatory on Earth (i.e., an
-\texttt{EarthLocation} object), and time values as \texttt{Time}
+\href{http://docs.astropy.org/en/stable/api/astropy.coordinates.EarthLocation.html}{\texttt{EarthLocation}} object), and time values as \astropyTime
 objects, the time corrections to shift to the solar system barycenter or
-heliocenter can now be computed with \package{astropy.time} using the
-\texttt{light\_travel\_time} method of a \texttt{Time} object.
+heliocenter can now be computed with \astropysubpkg{time} using the
+\texttt{light\_travel\_time} method of a \astropyTime object.
 
 \subsection{Data containers}
 
 \subsubsection{\package{nddata}}
 
-The \package{astropy.nddata} subpackage provides three types of functionality: an
+The \astropysubpkg{nddata} subpackage provides three types of functionality: an
 abstract interface for representing generic arbitrary-dimensional datasets
 intended primarily for subclassing by developers of other packages, concrete
 classes building on this interface, and utilities for manipulating these kind of
@@ -683,9 +695,10 @@ Additionally, the \texttt{CCDData} class also provides reading and writing from
 and to FITS files and uses data structures from \astropypkg, like \texttt{WCS},
 to represent the file contents abstractly.
 
-The \package{astropy.nddata.utils} module provides utilities that can operate
+The \href{http://docs.astropy.org/en/stable/nddata/utils.html}
+{\package{astropy.nddata.utils}} module provides utilities that can operate
 on either plain \package{numpy} arrays or any of the classes in the
-\package{astropy.nddata} subpackage. It features a class for representing
+\astropysubpkg{nddata} subpackage. It features a class for representing
 two-dimensional image cutouts, allowing one to easily link pixels in the cutout
 to those in the original image or vice versa, to convert
 between world and pixel coordinates in the cutout, and to overlay the cutout
@@ -695,16 +708,16 @@ or reduction are also provided.
 \subsubsection{Tables}
 \label{sec:table}
 
-The \package{astropy.table} subpackage provides functionality for
+The \astropysubpkg{table} subpackage provides functionality for
 representing and manipulating heterogeneous data. In some respects,
 this is similar to \package{numpy} record arrays \citep{numpy} or
 \package{pandas} dataframes \citep{pandas} but with modifications for
-astronomical data. Most notably, tables from \package{astropy.table}
+astronomical data. Most notably, tables from \astropysubpkg{table}
 allow for table or column metadata and can handle
 vectors or arrays as table entries.
 The subpackage was described in
 detail in \cite{astropy}.  Thus, in what follows, we only summarize
-key new features or updates to \package{astropy.table} since the
+key new features or updates to \astropysubpkg{table} since the
 previous \astropy paper. These are support for grouped table
 operations, table concatenation, and using array-valued
 \package{astropy} objects as table columns.
@@ -717,10 +730,10 @@ on the combination of source observed and the band, after which we combine the
 results for each combination of source and band in some way (e.g., finding
 the mean or standard deviation of the fluxes or magnitudes over time) or filter
 the groups based on user-defined criteria. These kinds of grouping and
-aggregation operations are now fully supported by \texttt{Table} objects.
+aggregation operations are now fully supported by \astropyTable objects.
 
 
-\texttt{Table} objects can now be combined in several different ways. If two
+\astropyTable objects can now be combined in several different ways. If two
 tables have the same columns, we may want to stack them ``vertically'' to create a
 new table with the same columns but all rows. If two tables are row-matched but
 have distinct columns, we may want to stack them ``horizontally'' to create a
@@ -729,24 +742,24 @@ table concatenation or join are also possible when two tables share some
 columns.
 
 
-The \texttt{Table} object now allows array-valued \texttt{Quantity}, celestial
-coordinate (\texttt{SkyCoord}), and date/time (\texttt{Time}) objects to
+The \astropyTable object now allows array-valued \astropyQuantity, celestial
+coordinate (\astropyskycoord), and date/time (\astropyTime) objects to
 be used as columns. It also provides a general way for other user-defined
 array-like objects to be used as columns.
 This makes it possible, for instance, to easily
 represent catalogs of sources or time series in \astropy, while having both the
-benefits of the \texttt{Table} object (e.g., accessing specific rows/columns
+benefits of the \astropyTable object (e.g., accessing specific rows/columns
 or groups of them and combining tables) and of, for example,
-the \texttt{SkyCoord} or the \texttt{Time} classes (e.g., converting the
+the \astropyskycoord or the \astropyTime classes (e.g., converting the
 coordinates to a different frame or accessing the date/time in the desired time scale).
 
 \subsection{\package{io}}
 
-The \package{astropy.io} subpackage provides support for reading and writing
+The \package{astropy.io} subpackages provide support for reading and writing
 data to a variety of ASCII and binary file formats, such as a wide range of
 ASCII data table formats, FITS, HDF5, and VOTable.
 It also provides a unified interface for reading and writing data with these
-different formats using the \package{astropy.table} subpackage.
+different formats using the \astropysubpkg{table} subpackage.
 For many common cases, this simplifies the process of file input and output (I/O) and
 reduces the need to master the separate details of all the I/O packages within
 \astropypkg. The file interface allows transparent compression of
@@ -764,7 +777,7 @@ possible to write a table to an ASCII-format file and read it back
 with no loss of information. The ECSV format has been designed to be
 both human-readable and compatible with most simple CSV readers.
 
-The \package{astropy.io.ascii} subpackage now includes a significantly faster
+The \astropyiosubpkg{ascii} subpackage now includes a significantly faster
 Cython/C engine for reading and writing ASCII files. This is available for most
 of the common formats. It also offers some additional features like parsing
 of different exponential notation styles, such as commonly produced
@@ -778,34 +791,36 @@ when dealing with compatible formats. Certain features of the full read
 / write interface are unavailable in the fast version, in which case the
 reader will by default fall back automatically to the pure-\python version.
 
-The \package{astropy.io.ascii} subpackage now provides the capability
+The \astropyiosubpkg{ascii} subpackage now provides the capability
 to read a table within an HTML file or web URL into an \astropypkg
-\texttt{Table} object. A \texttt{Table} object can now also
+\astropyTable object. A \astropyTable object can now also
 be written out as an HTML table.
 
 \subsubsection{FITS}
 
-The \package{astropy.io.fits} subpackage started as a direct port of the
+The \astropyiosubpkg{fits} subpackage started as a direct port of the
 PyFITS project \citep{PyFITS}. Therefore, it is pretty stable, with mostly bug
 fixes but also a few new features and performance improvements.  The API
 remains mostly compatible with PyFITS, which is now deprecated in favor of
 \astropypkg.
 
 Command-line scripts are now available for printing a summary of the HDUs in
-FITS file(s) (\texttt{fitsinfo}) and for printing the header information to
-the screen in a human-readable format (\texttt{fitsheader}).
+FITS file(s)
+(\href{http://docs.astropy.org/en/stable/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsinfo}{\texttt{fitsinfo}})
+and for printing the header information to the screen in a human-readable format
+(\href{http://docs.astropy.org/en/stable/io/fits/usage/scripts.html#module-astropy.io.fits.scripts.fitsheader}{\texttt{fitsheader}}).
 
 FITS files are now loaded \emph{lazily} by default, i.e., an object
 representing the list of HDUs is created but the data are not loaded into
 memory until requested.  This approach should provide substantial speed-ups
-when using the convenience functions (e.g., \texttt{getheader()} or
-\texttt{getdata()}) to get an HDU that is near the beginning in a file with
+when using the convenience functions (e.g., \href{http://docs.astropy.org/en/stable/io/fits/api/files.html#getheader}{\texttt{getheader()}} or
+\href{http://docs.astropy.org/en/stable/io/fits/api/files.html#getdata}{\texttt{getdata()}}) to get an HDU that is near the beginning in a file with
 many HDUs.
 
 \subsection{Modeling}
 \label{sec:modeling}
 
-The \package{astropy.modeling} subpackage provides a framework for representing
+The \astropysubpkg{modeling} subpackage provides a framework for representing
 analytical models and performing model evaluation and parameter fitting.
 The main motivation for this functionality was to create a framework that
 allows arbitrary combination of models to support the Generalized World
@@ -840,7 +855,7 @@ Another useful settable property of models is \texttt{Model.bounding\_box}. This
 
 \subsubsection{Model Sets}
 
-\package{astropy.modeling} provides an efficient way to set up the same type of model with many different sets of parameter values.
+\astropysubpkg{modeling} provides an efficient way to set up the same type of model with many different sets of parameter values.
 This creates a model set that can be efficiently evaluated. For example, in PSF (point spread function) photometry, all objects in an image will have a PSF of the same functional form, but with different positions and amplitudes.
 
 \subsubsection{Compound Models}
@@ -848,35 +863,37 @@ Models can be combined using arithmetic expressions. The result is also a model,
 
 \subsubsection{Fitting Models to Data}
 
-\package{astropy.modeling} provides several fitters which are wrappers around some of the \texttt{numpy} and \texttt{scipy.optimize} functions and provide support for specifying parameter constraints. The fitters take a model and data as input and return a copy of the model with the optimized parameter values set. The goal is to make it easy to extend the fitting framework to create new fitters. The optimizers available in \astropypkg version 2.0 are Levenberg--Marquardt (\texttt{scipy.optimize.leastsq}), Simplex (\texttt{scipy.optimize.fmin}), SLSQP (\texttt{scipy.optimize.slsqp}), and LinearLSQFitter (\texttt{numpy.linalg.lstsq} which provides exact solutions for linear models).
+\astropysubpkg{modeling} provides several fitters which are wrappers around some of the \texttt{numpy} and \texttt{scipy.optimize} functions and provide support for specifying parameter constraints. The fitters take a model and data as input and return a copy of the model with the optimized parameter values set. The goal is to make it easy to extend the fitting framework to create new fitters. The optimizers available in \astropypkg version 2.0 are Levenberg--Marquardt (\texttt{scipy.optimize.leastsq}), Simplex (\texttt{scipy.optimize.fmin}), SLSQP (\texttt{scipy.optimize.slsqp}), and LinearLSQFitter (\texttt{numpy.linalg.lstsq} which provides exact solutions for linear models).
 
 Modeling also supports a plugin system for fitters, which allows using the
 \astropypkg models with external fitters. An example of this is
 \package{SABA}\footnote{\url{https://github.com/astropy/saba}}, which is a bridge between
 Sherpa \citep{sherpa},
-and \package{astropy.modeling}, to bring the Sherpa fitters into \astropypkg.
+and \astropysubpkg{modeling}, to bring the Sherpa fitters into \astropypkg.
 
 \subsubsection{Creating New Models}
 If arithmetic combinations of existing models is not sufficient, new model
-classes can be defined in different ways. The \package{astropy.modeling}
+classes can be defined in different ways. The \astropysubpkg{modeling}
 package provides tools to turn a simple function into a full-featured model,
 but it also allows extending the built-in model class with arbitrary code.
 
 \subsubsection{Unit Support}
 
-The \package{astropy.modeling} subpackage now supports the representation,
-evaluation, and fitting of models using \texttt{Quantity} objects, which attach
+The \astropysubpkg{modeling} subpackage now supports the representation,
+evaluation, and fitting of models using \astropyQuantity objects, which attach
 units to scalar values or arrays of values. In practice, this means that one
 can, for example, fit a model to data with units and get parameters that also
 have units out, or initialize a model with parameters with units and evaluate
 it using input values with different but equivalent units. For example, the
-blackbody model (\texttt{BlackBody1D}) can be used to fit observed flux
-densities in a variety of units and as a function of different units of
-spectral coordinates (e.g., wavelength or frequency).
+blackbody model
+(\href{http://docs.astropy.org/en/stable/api/astropy.modeling.blackbody.BlackBody1D.html}{\texttt{BlackBody1D}})
+can be used to fit observed flux densities in a variety of units and as a
+function of different units of spectral coordinates (e.g., wavelength or
+frequency).
 
 \subsection{Convolution}
 
-The \package{astropy.convolution} subpackage implements
+The \astropysubpkg{convolution} subpackage implements
 \textit{normalized convolution} \citep[e.g.,][]{Knutsson1993}, an image
 reconstruction technique in which missing data are ignored during the
 convolution and replaced with values interpolated using the kernel.
@@ -908,9 +925,9 @@ consistency checks.
 
 \subsection{Visualization}
 
-The \package{astropy.visualization} subpackage provides functionality that can
+The \astropysubpkg{visualization} subpackage provides functionality that can
 be helpful when visualizing data. This includes a framework (previously the
-standalone \package{wcsaxes} package) for plotting
+standalone \astropywcsaxes package) for plotting
 astronomical images with coordinates with \package{matplotlib}, functionality related to image
 normalization (including both scaling and stretching), smart histogram
 plotting, red-green-blue (RGB) color image creation from separate images,
@@ -920,7 +937,7 @@ and custom plotting styles for \package{matplotlib}.
 
 \label{sec:stretch}
 
-\package{astropy.visualization} provides a framework for transforming values in
+\astropysubpkg{visualization} provides a framework for transforming values in
 images (and more generally any arrays), typically for the purpose of
 visualization. Two main types of transformations are normalization and
 stretching of image values.
@@ -944,7 +961,7 @@ the $[0,1]$ range.
 
 \package{matplotlib} allows a custom normalization and stretch to be used when
 displaying data by passing in a normalization object.
-The \package{astropy.visualization} package also provides a normalization class
+The \astropysubpkg{visualization} package also provides a normalization class
 that wraps the interval and stretches objects into a normalization object that
 \package{matplotlib} understands.
 
@@ -954,7 +971,7 @@ Astronomers dealing with observational imaging commonly need to make figures
 with images that include the correct coordinates and optionally display a
 coordinate grid. The challenge, however, is that the conceptual coordinate axes
 (such as longitude/latitude) need not be lined up with the pixel axes of the
-image. The \package{astropy.visualization.wcsaxes} subpackage implements a
+image. The \astropywcsaxes subpackage implements a
 generalized way of making figures from an image array and a WCS object
 that provides the transformation between pixel and world coordinates.
 
@@ -974,11 +991,11 @@ for example, Aitoff projections.
 
 This subpackage differs from \package{APLpy} \citep{aplpy}, in that the latter
 focuses on providing a very high-level interface to plotting that requires very
-few lines of code to get a good result, whereas \package{wcsaxes} defines an
+few lines of code to get a good result, whereas \astropywcsaxes defines an
 interface that is much closer to that of \package{matplotlib} \citep{matplotlib}.
 This enables significantly more advanced visualizations.
 
-An example of a visualization made with \package{wcsaxes} is shown in
+An example of a visualization made with \astropywcsaxes is shown in
 \figurename~\ref{fig:wcsaxes}. This example illustrates the ability to
 overlay multiple coordinate systems and customize which ticks/labels are shown
 on which axes around the image. This also uses the image stretching
@@ -988,7 +1005,7 @@ square-root stretch (automatically updating the tick positions in the colorbar).
 \begin{figure}
 \includegraphics[width=\textwidth]{cygnus_x_spitzer.pdf}
 \caption{%
-An example of figure made using the \package{astropy.visualization.wcsaxes}
+An example of figure made using the \astropywcsaxes
 subpackage, using \textit{Spitzer}/IRAC 8.0~$\mu$m data from the Cygnus-X
 \textit{Spitzer} Legacy survey \citep{cygnusx}.
 \label{fig:wcsaxes}
@@ -997,7 +1014,7 @@ subpackage, using \textit{Spitzer}/IRAC 8.0~$\mu$m data from the Cygnus-X
 
 \subsubsection{Choosing Histogram Bins}
 
-\package{astropy.visualization} also provides a histogram function, which is a
+\astropysubpkg{visualization} also provides a histogram function, which is a
 generalization of \texttt{matplotlib}’s histogram function, to allow for a more
 flexible specification of histogram bins.  The function provides several methods
 of automatically tuning the histogram bin size. It has a syntax identical to
@@ -1009,7 +1026,7 @@ automatic bin selection: ``blocks'', ``knuth'', ``scott'', or ``freedman''.
 
 \cite{Lupton2004} describe an ``optimal'' algorithm for producing
 RGB composite images from three separate high-dynamic range
-arrays. The \package{astropy.visualization} subpackage provides a convenience
+arrays. The \astropysubpkg{visualization} subpackage provides a convenience
 function to create such a color image.  It also includes an associated set of
 classes to provide alternate scalings.
 This functionality was contributed by developers from the Large Synoptic Survey
@@ -1021,15 +1038,16 @@ variation on this technique.  As an example, in \figurename~\ref{fig:ngc6977},
 we show an RGB color image of the Hickson 88 group, centered near
 NGC~6977.\footnote{\url{http://skyserver.sdss.org/dr13/en/tools/chart/navi.aspx?ra=313.12381&dec=-5.74611}}
 This image was generated from SDSS images using the
-\package{astropy.visualization} tools.
+\astropysubpkg{visualization} tools.
 
 \begin{figure}
 \includegraphics[width=\textwidth]{ngc6977}
 \caption{An RGB color image of the region near the Hickson 88 group
-constructed from SDSS images and the \package{astropy.visualization}
+constructed from SDSS images and the \astropysubpkg{visualization}
 tools.
-This example uses \package{astropy.visualization.wcsaxes} to display the
-sky coordinate grid, and the \texttt{astropy.visualization.make\_lupton\_rgb()}
+This example uses \astropywcsaxes to display the
+sky coordinate grid, and the
+\href{http://docs.astropy.org/en/stable/api/astropy.visualization.make_lupton_rgb.html}{\texttt{make\_lupton\_rgb()}}
 function to produce the RGB image from three SDSS filter images ($g$, $r$, $i$).
 The left and right panel images show two different parameter choices for the
 stretch and softening parameters (shown in the titles).
@@ -1039,19 +1057,19 @@ stretch and softening parameters (shown in the titles).
 
 \subsection{Cosmology}
 
-The \package{cosmology} subpackage contains classes for representing different
-cosmologies and functions for calculating commonly used quantities such as
-look-back time and distance.   The subpackage was described in detail in
+The \astropysubpkg{cosmology} subpackage contains classes for representing
+different cosmologies and functions for calculating commonly used quantities
+such as look-back time and distance.   The subpackage was described in detail in
 \cite{astropy}.  The default cosmology in \astropypkg version 2.0 is given by
 the values in \cite{2016A&A...594A..13P}.
 
 \subsection{Statistics}
 
-The \package{astropy.stats} package provides statistical tools that
+The \astropysubpkg{stats} package provides statistical tools that
 are useful for astronomy and are either not found in or extend
 the available functionality of other \python statistics packages, such
 as \package{scipy} \citep{scipy} or \package{statsmodels}
-\citep{seabold2010statsmodels}.  \package{astropy.stats} contains
+\citep{seabold2010statsmodels}.  \astropysubpkg{stats} contains
 a range of functionality used by many different disciplines
 in astronomy. It is not a complete set of statistical tools, but rather
 a still growing collection of useful features.
@@ -1061,7 +1079,7 @@ a still growing collection of useful features.
 
 Robust statistics provide reliable estimates of basic statistics for complex
 distributions that largely mitigate the effects of outliers.
-\package{astropy.stats} includes several robust statistical functions that are
+\astropysubpkg{stats} includes several robust statistical functions that are
 commonly used in astronomy, such as sigma clipping methods for rejecting
 outliers, median absolute deviation functions, and biweight estimators,
 which have been used to calculate the velocity dispersion of galaxy clusters
@@ -1072,17 +1090,17 @@ which have been used to calculate the velocity dispersion of galaxy clusters
 Astronomers often need to compute statistics of quantities evaluated on a
 circle, such as sky direction or polarization angle.
 A set of circular statistical estimators based on \citet{JammalamadakaSengupta}
-are implemented in \package{astropy.stats}.  These functions provide
+are implemented in \astropysubpkg{stats}.  These functions provide
 measurements of the circular mean, variance, and moment.   All of these
 functions work with both \texttt{numpy.ndarrays} (assumed to be in radians) and
-\texttt{Quantity} objects.  In addition, the subpackage includes
+\astropyQuantity objects.  In addition, the subpackage includes
 tests for Rayleigh Test, \texttt{vtest}, and a function to compute the maximum
 likelihood estimator for the parameters of the von Mises distribution.
 
 \subsubsection{Lomb-Scargle Periodograms}
 
 Periodic analysis of unevenly-spaced time series is common across many
-sub-fields of astronomy. The \package{astropy.stats} package now includes
+sub-fields of astronomy. The \astropysubpkg{stats} package now includes
 several efficient implementations of the Lomb-Scargle periodogram
 \citep{Lomb76, Scargle82} and several generalizations, including floating mean
 models \citep{Zechmeister09}, truncated Fourier models \citep{Bretthorst2003},
@@ -1097,7 +1115,7 @@ interpretation of periodogram results involves some subtleties; for a thorough
 discussion of this issue, see \citet[][in press]{VanderPlas2018}.
 
 \subsubsection{Bayesian Blocks and Histogram Binning}
-\package{astropy.stats} also includes an implementation of
+\astropysubpkg{stats} also includes an implementation of
 {\it Bayesian Blocks} \citep{Scargle2013}, an algorithm for analysis of
 break-points in non-periodic astronomical time-series. One interesting
 application of Bayesian Blocks is its use in determining optimal histogram
@@ -1303,7 +1321,7 @@ We would like to thank the members of the community that have
 contributed to \astropy,
 that have opened issues and provided feedback, and have supported the
 project in a number of different ways.  We would like to acknowledge
-Alex Conley and Neil Crighton for maintaining the  \package{cosmology}
+Alex Conley and Neil Crighton for maintaining the \astropysubpkg{cosmology}
 subpackage.
 
 The \astropy community is supported by and makes use


### PR DESCRIPTION
I went a little crazy here and turned subpackage names, class names, and function names into links to the stable documentation. Not sure if we want this, but the effort is done! 

Do we also want explicit links to examples?